### PR TITLE
Fix vorp:Tip name in AddEventHandler

### DIFF
--- a/client/cl_notifications.lua
+++ b/client/cl_notifications.lua
@@ -20,7 +20,7 @@ AddEventHandler('vorp:TipRight', function(text, duration)
 end)
 
 RegisterNetEvent('vorp:Tip')
-AddEventHandler('vorp:tip', function(text, duration)
+AddEventHandler('vorp:Tip', function(text, duration)
     exports.vorp_core:DisplayTip(tostring(text), tonumber(duration))
 end)
 


### PR DESCRIPTION
The vorp:Tip client event was not working because it was not the same name as the RegisterNetEvent