### PR TITLE
Bans and warns

### DIFF
--- a/client/cl_adminactions.lua
+++ b/client/cl_adminactions.lua
@@ -162,6 +162,25 @@ function delHorse()
 end
 
 
+
+function BanPlayerByUserId(target, banTime)
+    TriggerServerEvent("vorpbans:addtodb", true, target, banTime)
+end
+
+function UnbanPlayerByUserId(target)
+    TriggerServerEvent("vorpbans:addtodb", false, target, 0)
+end
+
+function WarnPlayerByUserId(target)
+    TriggerServerEvent("vorpwarns:addtodb", true, target)
+end
+
+function UnwarnPlayerByUserId(target)
+    TriggerServerEvent("vorpwarns:addtodb", false, target)
+end
+
+
+
 RegisterNetEvent('vorp:deleteVehicle')
 AddEventHandler('vorp:deleteVehicle', function(radius)
     local player = PlayerPedId()
@@ -219,4 +238,24 @@ end)
 RegisterNetEvent('vorp:heal')
 AddEventHandler('vorp:heal', function()
     HealPlayer()
+end)
+
+RegisterNetEvent('vorp:ban')
+AddEventHandler('vorp:ban', function(target, banTime)
+    BanPlayerByUserId(target, banTime)
+end)
+
+RegisterNetEvent('vorp:unban')
+AddEventHandler('vorp:unban', function(target)
+    UnbanPlayerByUserId(target)
+end)
+
+RegisterNetEvent('vorp:warn')
+AddEventHandler('vorp:warn', function(target)
+    WarnPlayerByUserId(target)
+end)
+
+RegisterNetEvent('vorp:unwarn')
+AddEventHandler('vorp:unwarn', function(target)
+    UnwarnPlayerByUserId(target)
 end)

--- a/config.lua
+++ b/config.lua
@@ -12,7 +12,7 @@ Config = {
   initJob                  = "unemployed", -- leave it like this
   initJobGrade             = 0, -- leave it like this
   initGroup                = "user", -- leave it like this
-  Whitelist                = false, -- if true set up webhook bellow thats where you get the user id to whitelist them when they try to join,  then in game use the command to whitelist a user. or remove
+  Whitelist                = false, 
   AllowWhitelistAutoUpdate = false,
   MaxCharacters            = 5, --MAX ALLOWED TO BE CREATED
   maxHealth                = 4, -- 10 is FULL 0 IS EMPTY define max outer core for players
@@ -44,6 +44,7 @@ Config = {
   HealPlayerWebhook = "", --HEALPLAYER
   ReviveWebhook     = "", --REVIVE
   WhitelistWebhook  = "", --WHITELIST
+  BanWarnWebhook    = "", --BANS/WARNS
 
   ------------------------------------------------------------------------------
   ---------------------------- VOICE -------------------------------------------
@@ -117,6 +118,7 @@ Config = {
   KeyShowIds = "0x8CC9CD42", -- Press X
   ActiveEagleEye = true,
   ActiveDeadEye = false,
+  TimeZoneDifference = 1, -- Your time zone difference with UTC in winter time
 
   ----------------------------------------------------------------------------
   --------------------------- COMMAND PERMISSION -----------------------------
@@ -148,7 +150,12 @@ Config = {
     NoPermissions      = "You don't have enough permissions",
     CheckingIdentifier = "Checking Identifiers",
     LoadingUser        = "Loading User",
-    BannedUser         = "You Are Banned",
+    BannedUser         = "You Are Banned Until ",
+    DateTimeFormat     = "%d/%m/%y %H:%M:%S", -- Set wished DateTimeFormat for output in ban notification
+    TimeZone           = " CET", -- Set your timezone
+    DropReasonBanned   = "You were banned from the server until ",
+    Warned             = "You were warned",
+    Unwarned           = "You were unwarned",
     TitleOnDead        = "Do /alertdoctor in chat to request doctors aid",
     SubTitleOnDead     = "You can respawn in %s seconds",
     RespawnIn          = "You can respawn in ",
@@ -161,9 +168,6 @@ Config = {
     mustBeSeated       = "VORP: You must be in the driver's seat!",
     wagonInFront       = "VORP: You must be seated or near a wagon to delete it!",
     cantCarry          = "VORP: Can't carry more weapons!",
-    Hold               = "HOLD ON!!",
-    Load               = "You are loading in",
-    Almost             = "Almost there..."
   },
 
 

--- a/config.lua
+++ b/config.lua
@@ -168,6 +168,9 @@ Config = {
     mustBeSeated       = "VORP: You must be in the driver's seat!",
     wagonInFront       = "VORP: You must be seated or near a wagon to delete it!",
     cantCarry          = "VORP: Can't carry more weapons!",
+    Hold               = "HOLD ON!!",
+    Load               = "You are loading in",
+    Almost             = "Almost there..."
   },
 
 

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -27,7 +27,7 @@ files {
 ui_page 'ui/hud.html'
 
 --dont touch
-version '1.1'
+version '1.2'
 vorp_checker 'yes'
 vorp_name '^4Resource version Check^3 '
 vorp_github 'https://github.com/VORPCORE/vorp-core-lua'

--- a/server/sv_bans.lua
+++ b/server/sv_bans.lua
@@ -1,0 +1,56 @@
+RegisterNetEvent("vorpbans:addtodb")
+AddEventHandler("vorpbans:addtodb", function (status, id, datetime)
+    local sid = IdsToIdentifiers[id]
+
+    if status == true then
+        for _, player in ipairs(GetPlayers()) do
+            if sid == GetPlayerIdentifiers(player)[1] then
+                local bannedUntil = os.date(Config.Langs["DateTimeFormat"], datetime+Config.TimeZoneDifference*3600)
+                DropPlayer(player, Config.Langs["DropReasonBanned"]..bannedUntil..Config.Langs["TimeZone"])
+                break
+            end
+        end
+    end
+
+    exports.ghmattimysql:execute("UPDATE users SET banned = @banned, banneduntil=@time WHERE identifier = @identifier", {['@banned'] = status, ['@time'] = datetime, ['@identifier'] = sid}, function(result) end)
+end)
+
+RegisterNetEvent("vorpwarns:addtodb")
+AddEventHandler("vorpwarns:addtodb", function (status, id)
+    local sid = IdsToIdentifiers[id]
+
+    local resultList = exports.ghmattimysql:executeSync("SELECT * FROM users WHERE identifier = ?", { sid })
+
+    local warnings
+
+    if _users[sid] then
+        local user = _users[sid].GetUser()
+        warnings = user.getPlayerwarnings()
+
+        for _, player in ipairs(GetPlayers()) do
+            if sid == GetPlayerIdentifiers(player)[1] then
+                if status == true then
+                    TriggerClientEvent("vorp:Tip", player, Config.Langs["Warned"], 10000)
+                    warnings = warnings + 1
+                else
+                    TriggerClientEvent("vorp:Tip", player, Config.Langs["Unwarned"], 10000)
+                    warnings = warnings - 1
+                end
+                break
+            end
+        end
+
+        user.setPlayerWarnings(warnings)
+    else
+        local user = resultList[1]
+        warnings = user["warnings"]
+        if status == true then
+            warnings = warnings + 1
+        else
+            warnings = warnings - 1
+        end
+    end
+    
+
+    exports.ghmattimysql:execute("UPDATE users SET warnings = @warnings WHERE identifier = @identifier", {['@warnings'] = warnings, ['@identifier'] = sid}, function(result) end)
+end)

--- a/server/sv_commands.lua
+++ b/server/sv_commands.lua
@@ -370,9 +370,10 @@ RegisterCommand("wlplayer", function(source, args, rawCommand)
             local Identifier = GetPlayerIdentifier(_source)
             local discordIdentity = GetIdentity(_source, "discord")
             local discordId = string.sub(discordIdentity, 9)
+            local ip = GetPlayerEndpoint(_source)
             local steamName = GetPlayerName(_source)
             local text = "Was whitelisted"
-            local message = "**Steam name: **`" .. steamName .. "`**\nIdentifier**`" .. Identifier .. "` \n**Discord:** <@" .. discordId .. ">**\nIP: **`" .. target .. "`\n **Action:** `" .. text .. "`"
+            local message = "**Steam name: **`" .. steamName .. "`**\nIdentifier**`" .. Identifier .. "` \n**Discord:** <@" .. discordId .. ">**\nIP: **`" .. ip .. "` \n **User-Id:** `" .. target .. "`\n **Action:** `" .. text .. "`"
             if args then
                 if user.group == Config.Group.Admin or user.group == Config.Group.Mod then
                     TriggerEvent("vorp:whitelistWebhook", "📋` /wlplayer command` ", message, color)
@@ -399,8 +400,9 @@ RegisterCommand("unwlplayer", function(source, args, rawCommand)
             local discordIdentity = GetIdentity(_source, "discord")
             local discordId = string.sub(discordIdentity, 9)
             local steamName = GetPlayerName(_source)
-            local text = "was unwhitelisted"
-            local message = "**Steam name: **`" .. steamName .. "`**\nIdentifier**`" .. Identifier .. "` \n**Discord:** <@" .. discordId .. ">**\nIP: **`" .. target .. "`\n **Action:** `" .. text .. "`"
+            local ip = GetPlayerEndpoint(_source)
+            local text = "Was unwhitelisted"
+            local message = "**Steam name: **`" .. steamName .. "`**\nIdentifier**`" .. Identifier .. "` \n**Discord:** <@" .. discordId .. ">**\nIP: **`" .. ip .. "` \n **User-Id:** `" .. target .. "`\n **Action:** `" .. text .. "`"
             if args then
                 if user.group == Config.Group.Admin or user.group == Config.Group.Mod then
                     TriggerEvent("vorp:whitelistWebhook", "📋` /unwlplayer command` ", message, color)
@@ -417,6 +419,104 @@ RegisterCommand("unwlplayer", function(source, args, rawCommand)
         TriggerEvent("vorp:unwhitelistPlayer", target)
     end
 end)
+
+---------------------------------------------------------------------------------------------------------
+--------------------------------------- BANS - WARNS ----------------------------------------------------
+RegisterCommand("ban", function(source, args, rawCommand)
+    local _source = source
+    TriggerEvent("vorp:getCharacter", _source, function(user)
+        local target = tonumber(args[1])
+        local banTime = tonumber(args[2])
+        local datetime = os.time(os.date("!*t"))
+        datetime = datetime + banTime*3600
+        local Identifier = GetPlayerIdentifier(_source)
+        local discordIdentity = GetIdentity(_source, "discord")
+        local discordId = string.sub(discordIdentity, 9)
+        local ip = GetPlayerEndpoint(_source)
+        local steamName = GetPlayerName(_source)
+        local text = "Was banned"
+        local message = "**Steam name: **`" .. steamName .. "`**\nIdentifier**`" .. Identifier .. "` \n**Discord:** <@" .. discordId .. ">**\nIP: **`" .. ip .. "` \n **User-Id:** `" .. target .. "`\n **Action:** `" .. text .. "`"
+        if args then
+            if user.group == Config.Group.Admin or user.group == Config.Group.Mod then
+                TriggerEvent("vorp:banWarnWebhook", "📋` /ban command` ", message, color)
+                TriggerClientEvent("vorp:ban", _source, target, datetime)
+            else
+                TriggerClientEvent("vorp:Tip", _source, Config.Langs["NoPermissions"], 4000)
+            end
+        end
+        
+    end)
+end)
+
+RegisterCommand("unban", function(source, args, rawCommand)
+    local _source = source
+    TriggerEvent("vorp:getCharacter", _source, function(user)
+        local target = tonumber(args[1])
+        local Identifier = GetPlayerIdentifier(_source)
+        local discordIdentity = GetIdentity(_source, "discord")
+        local discordId = string.sub(discordIdentity, 9)
+        local steamName = GetPlayerName(_source)
+        local ip = GetPlayerEndpoint(_source)
+        local text = "Was unbanned"
+        local message = "**Steam name: **`" .. steamName .. "`**\nIdentifier**`" .. Identifier .. "` \n**Discord:** <@" .. discordId .. ">**\nIP: **`" .. ip .. "` \n **User-Id:** `" .. target .. "`\n **Action:** `" .. text .. "`"
+        if args then
+            if user.group == Config.Group.Admin or user.group == Config.Group.Mod then
+                TriggerEvent("vorp:banWarnWebhook", "📋` /unban command` ", message, color)
+                TriggerClientEvent("vorp:unban", _source, target)
+            else
+                TriggerClientEvent("vorp:Tip", _source, Config.Langs["NoPermissions"], 4000)
+            end
+        end
+        
+    end)
+end)
+
+RegisterCommand("warn", function(source, args, rawCommand)
+    local _source = source
+    TriggerEvent("vorp:getCharacter", _source, function(user)
+        local target = tonumber(args[1])
+        local Identifier = GetPlayerIdentifier(_source)
+        local discordIdentity = GetIdentity(_source, "discord")
+        local discordId = string.sub(discordIdentity, 9)
+        local ip = GetPlayerEndpoint(_source)
+        local steamName = GetPlayerName(_source)
+        local text = "Was warned"
+        local message = "**Steam name: **`" .. steamName .. "`**\nIdentifier**`" .. Identifier .. "` \n**Discord:** <@" .. discordId .. ">**\nIP: **`" .. ip .. "` \n **User-Id:** `" .. target .. "`\n **Action:** `" .. text .. "`"
+        if args then
+            if user.group == Config.Group.Admin or user.group == Config.Group.Mod then
+                TriggerEvent("vorp:banWarnWebhook", "📋` /warn command` ", message, color)
+                TriggerClientEvent("vorp:warn", _source, target)
+            else
+                TriggerClientEvent("vorp:Tip", _source, Config.Langs["NoPermissions"], 4000)
+            end
+        end
+        
+    end)
+end)
+
+RegisterCommand("unwarn", function(source, args, rawCommand)
+    local _source = source
+    TriggerEvent("vorp:getCharacter", _source, function(user)
+        local target = tonumber(args[1])
+        local Identifier = GetPlayerIdentifier(_source)
+        local discordIdentity = GetIdentity(_source, "discord")
+        local discordId = string.sub(discordIdentity, 9)
+        local steamName = GetPlayerName(_source)
+        local ip = GetPlayerEndpoint(_source)
+        local text = "Was unwarned"
+        local message = "**Steam name: **`" .. steamName .. "`**\nIdentifier**`" .. Identifier .. "` \n**Discord:** <@" .. discordId .. ">**\nIP: **`" .. ip .. "` \n **User-Id:** `" .. target .. "`\n **Action:** `" .. text .. "`"
+        if args then
+            if user.group == Config.Group.Admin or user.group == Config.Group.Mod then
+                TriggerEvent("vorp:banWarnWebhook", "📋` /unwarn command` ", message, color)
+                TriggerClientEvent("vorp:unwarn", _source, target)
+            else
+                TriggerClientEvent("vorp:Tip", _source, Config.Langs["NoPermissions"], 4000)
+            end
+        end
+        
+    end)
+end)
+
 
 ---------------------------------------------------------------------------------------------------------
 ----------------------------------- CHAT ADD SUGGESTION --------------------------------------------------
@@ -496,6 +596,22 @@ AddEventHandler("vorp:chatSuggestion", function()
         { name = "Id", help = 'player ID from Discord user-id' },
     })
 
+    TriggerClientEvent("chat:addSuggestion", _source, "/ban", " VORPcore command to ban players.", {
+        { name = "Id", help = 'player ID from Discord user-id' },
+        { name = "Time", help = 'Time of ban in hours' },
+    })
+
+    TriggerClientEvent("chat:addSuggestion", _source, "/unban", " VORPcore command to unban players.", {
+        { name = "Id", help = 'player ID from Discord user-id' },
+    })
+
+    TriggerClientEvent("chat:addSuggestion", _source, "/warn", " VORPcore command to warn players.", {
+        { name = "Id", help = 'player ID from Discord user-id' },
+    })
+
+    TriggerClientEvent("chat:addSuggestion", _source, "/unwarn", " VORPcore command to unwarn players.", {
+        { name = "Id", help = 'player ID from Discord user-id' },
+    })
 
 
 end)

--- a/server/sv_loadusers.lua
+++ b/server/sv_loadusers.lua
@@ -16,8 +16,15 @@ function LoadUser(source, setKickReason, deferrals, identifier, license)
     if #resultList > 0 then
         local user = resultList[1]
         if user["banned"] == 1 then
-            deferrals.done(Config.Langs["BannedUser"])
-            setKickReason(Config.Langs["BannedUser"])
+            local bannedUntilTime = user["banneduntil"]
+            local currentTime = tonumber(os.time(os.date("!*t")))
+            if bannedUntilTime > currentTime then
+                local bannedUntil = os.date(Config.Langs["DateTimeFormat"], bannedUntilTime+Config.TimeZoneDifference*3600)
+                deferrals.done(Config.Langs["BannedUser"]..bannedUntil..Config.Langs["TimeZone"])
+                setKickReason(Config.Langs["BannedUser"]..bannedUntil..Config.Langs["TimeZone"])
+            else
+                TriggerEvent("vorpbans:addtodb", false, IdentifiersToId[identifier], 0)
+            end
         end
 
         _users[identifier] = User(source, identifier, user["group"], user["warnings"], license)

--- a/server/sv_logs.lua
+++ b/server/sv_logs.lua
@@ -105,6 +105,11 @@ RegisterServerEvent('vorp:whitelistWebhook')
 AddEventHandler('vorp:whitelistWebhook', function(title, description, text, color)
     Discord(Config.WhitelistWebhook, title, description, text, color)
 end)
+
+RegisterServerEvent('vorp:banWarnWebhook')
+AddEventHandler('vorp:banWarnWebhook', function(title, description, text, color)
+    Discord(Config.BanWarnWebhook, title, description, text, color)
+end)
 -----------------------------------------------------------------------------------------------------------------------
 ------------------------------------------------ RICH PRESENCE --------------------------------------------------------
 RegisterServerEvent("vorprich:getplayers")

--- a/server/sv_whitelist.lua
+++ b/server/sv_whitelist.lua
@@ -1,4 +1,5 @@
-local whitelist, identifiersToId, whitelistActive, currentFreeId = {}, {}, Config.Whitelist, 1
+local whitelist,  whitelistActive, currentFreeId = {}, Config.Whitelist, 1
+IdentifiersToId, IdsToIdentifiers = {}, {}
 
 -- function AddUserToWhitelist(identifier)
 --     local id = identifiersToId[identifier]
@@ -28,7 +29,8 @@ local function LoadWhitelist()
         if #result > 0 then
             for k,v in ipairs(result) do
                 whitelist[v.id] = v.status
-                identifiersToId[v.identifier] = v.id
+                IdsToIdentifiers[v.id] = v.identifier
+                IdentifiersToId[v.identifier] = v.id
             end
             currentFreeId = #whitelist+1
         end
@@ -43,7 +45,8 @@ local function SetUpdateWhitelistPolicy()
             if #result > 0 then
                 for k,v in ipairs(result) do
                     whitelist[v.id] = v.status
-                    identifiersToId[v.identifier] = v.id
+                    IdsToIdentifiers[v.id] = v.identifier
+                    IdentifiersToId[v.identifier] = v.id
                 end
                 currentFreeId = #whitelist+1
             end
@@ -72,11 +75,11 @@ function GetLicenseID(src)
 end
 
 function InsertIntoWhitelist(identifier)
-    if identifiersToId[identifier] then
-        return identifiersToId[identifier]
+    if IdentifiersToId[identifier] then
+        return IdentifiersToId[identifier]
     end
 
-    identifiersToId[identifier] = currentFreeId
+    IdentifiersToId[identifier] = currentFreeId
     whitelist[currentFreeId] = false
 
     exports.ghmattimysql:execute("INSERT INTO whitelist (identifier, status) VALUES (@identifier, @status)", {['@identifier'] = identifier, ['@status']=false}, function(result) end)
@@ -111,7 +114,7 @@ AddEventHandler("playerConnecting", function(playerName, setKickReason, deferral
     end
 
     if whitelistActive then
-        playerWlId = identifiersToId[steamIdentifier]
+        playerWlId = IdentifiersToId[steamIdentifier]
         if whitelist[playerWlId] then
             deferrals.done()
             userEntering = true

--- a/version
+++ b/version
@@ -1,14 +1,14 @@
 <1.2>
 - Bans and warns
 - update 
-    cl_adminactions.lua
-    sv_commands.lua
-    sv_bans.lua
-    sv_logs.lua
-    sv_whitelist.lua
-    sv_loadusers.lua
-    vorpv2.sql
-    config.lua file 
+-   cl_adminactions.lua
+-   sv_commands.lua
+-   sv_bans.lua
+-   sv_logs.lua
+-   sv_whitelist.lua
+-   sv_loadusers.lua
+-   vorpv2.sql
+-   config.lua file 
 - update fxmanifest.lua if you dont the version check will fail
 <1.1>
 - fix for incorrect data when player crashes when in selectchar area

--- a/version
+++ b/version
@@ -1,5 +1,13 @@
-<1.1>
-- fix for incorrect data when player crashes when in selectchar area
-- update cl_spanwplayer.lua file 
+<1.2>
+- Bans and warns
+- update 
+    cl_adminactions.lua
+    sv_commands.lua
+    sv_bans.lua
+    sv_logs.lua
+    sv_whitelist.lua
+    sv_loadusers.lua
+    vorpv2.sql
+    config.lua file 
 - update fxmanifest.lua if you dont the version check will fail
-<1.0>
+<1.1>

--- a/version
+++ b/version
@@ -11,3 +11,7 @@
     config.lua file 
 - update fxmanifest.lua if you dont the version check will fail
 <1.1>
+- fix for incorrect data when player crashes when in selectchar area
+- update cl_spanwplayer.lua file 
+- update fxmanifest.lua if you dont the version check will fail
+<1.0>

--- a/vorpv2.sql
+++ b/vorpv2.sql
@@ -12,7 +12,8 @@ CREATE TABLE IF NOT EXISTS `users` (
   `identifier` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
   `group` varchar(50) DEFAULT 'user',
   `warnings` int(11) DEFAULT 0,
-  `banned` tinyint(4) DEFAULT 0,
+  `banned` boolean,
+  `banneduntil` int(10) DEFAULT 0,
   PRIMARY KEY (`identifier`),
   UNIQUE KEY `identifier` (`identifier`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
@@ -22,7 +23,7 @@ DROP TABLE IF EXISTS `characters`;
 CREATE TABLE `characters`  (
   `identifier` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '',
   `charidentifier` int(11) NOT NULL AUTO_INCREMENT,
-   `steamname` varchar(50) COLLATE utf8mb4_bin NOT NULL DEFAULT '',
+  `steamname` varchar(50) COLLATE utf8mb4_bin NOT NULL DEFAULT '',
   `group` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NULL DEFAULT 'user',
   `money` double(11, 2) NULL DEFAULT 0,
   `gold` double(11, 2) NULL DEFAULT 0,


### PR DESCRIPTION
Reinvention of wheel for bans and warns. Everything using user-ids (the same as for whitelists)

To update are 
cl_adminactions.lua
sv_commands.lua
sv_bans.lua
sv_logs.lua
sv_whitelist.lua
sv_loadusers.lua
vorpv2.sql
config.lua

Users with already created `users` database can edit their db tables without deleting and creating again with SQL Code below
```
ALTER TABLE `users`
ADD COLUMN `banneduntil` int(10) DEFAULT 0 AFTER `banned`
CHANGE `banned` `banned` BOOLEAN NOT NULL DEFAULT FALSE;
```

Also small fix for whitelist discord logs