### PR TITLE
Fix for NewPlayerWebhook

### DIFF
--- a/server/sv_logs.lua
+++ b/server/sv_logs.lua
@@ -30,17 +30,23 @@ function Discord(webhook, title, description, text, color)
 end
 
 function GetIdentity(source, identity)
-    local num = 0
-    local num2 = GetNumPlayerIdentifiers(source)
+    -- local num = 0
+    -- local num2 = GetNumPlayerIdentifiers(source)
 
-    if GetNumPlayerIdentifiers(source) > 0 then
-        local ident = nil
-        while num < num2 and not ident do
-            local a = GetPlayerIdentifier(source, num)
-            if string.find(a, identity) then ident = a end
-            num = num + 1
+    -- if GetNumPlayerIdentifiers(source) > 0 then
+    --     local ident = nil
+    --     while num < num2 and not ident do
+    --         local a = GetPlayerIdentifier(source, num)
+    --         if string.find(a, identity) then ident = a end
+    --         num = num + 1
+    --     end
+    --     return ident;
+    -- end
+    
+    for k,v in pairs(GetPlayerIdentifiers(source))do
+        if string.sub(v, 1, string.len(identity..":")) == identity..":" then
+            return v
         end
-        return ident;
     end
 end
 

--- a/server/sv_whitelist.lua
+++ b/server/sv_whitelist.lua
@@ -77,7 +77,8 @@ function InsertIntoWhitelist(identifier)
         return IdentifiersToId[identifier]
     end
     
-    exports.ghmattimysql:executeSync("INSERT INTO whitelist (identifier, status) VALUES (@identifier, @status)", {['@identifier'] = identifier, ['@status']=false}, function(result) end)
+    exports.ghmattimysql:executeSync("INSERT INTO whitelist (identifier, status, firstconnection) VALUES (@identifier, @status, @firstcon)",
+                                    {['@identifier'] = identifier, ['@status']=false, ['@firstcon']=true}, function(result) end)
     local entryList = exports.ghmattimysql:executeSync('SELECT * FROM whitelist WHERE identifier = ?', { identifier })
     local currentFreeId
     if #entryList > 0 then

--- a/vorpv2.sql
+++ b/vorpv2.sql
@@ -1,7 +1,10 @@
-CREATE TABLE IF NOT EXISTS `whitelist`  (
+
+DROP TABLE IF EXISTS `whitelist`;
+CREATE TABLE `whitelist`  (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `identifier` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
   `status` boolean,
+  `firstconnection` boolean,
   PRIMARY KEY (`id`) USING BTREE,
   UNIQUE INDEX `identifier`(`identifier`) USING BTREE
 ) ENGINE = InnoDB AUTO_INCREMENT = 1 CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci ROW_FORMAT = DYNAMIC;
@@ -17,7 +20,8 @@ CREATE TABLE IF NOT EXISTS `users` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 
-CREATE TABLE IF NOT EXISTS `characters`  (
+DROP TABLE IF EXISTS `characters`;
+CREATE TABLE `characters`  (
   `identifier` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '',
   `charidentifier` int(11) NOT NULL AUTO_INCREMENT,
   `steamname` varchar(50) COLLATE utf8mb4_bin NOT NULL DEFAULT '',
@@ -40,12 +44,3 @@ CREATE TABLE IF NOT EXISTS `characters`  (
   INDEX `charidentifier`(`charidentifier`) USING BTREE,
   CONSTRAINT `FK_characters_users` FOREIGN KEY (`identifier`) REFERENCES `users` (`identifier`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE = InnoDB AUTO_INCREMENT = 1 CHARACTER SET = utf8mb4 COLLATE = utf8mb4_bin ROW_FORMAT = DYNAMIC;
-
-
--------------ANY NEW UPDATES TO THE TABLES ABOVE NEED TO HAVE TABLE ALTERS ALSO ADDED BELOW FOR THOSE WHO ALREADY HAVE SERVERS RUNNING.
--- The following updates tables that were not included in the original table (Support for those who already have the tables above)
-ALTER TABLE `users` ALTER COLUMN  `banned` boolean;
-ALTER TABLE `users` ADD `banneduntil` int(10) DEFAULT 0;
-ALTER TABLE `whitelist` ADD `status` boolean
-
-

--- a/vorpv2.sql
+++ b/vorpv2.sql
@@ -1,10 +1,8 @@
-
-DROP TABLE IF EXISTS `whitelist`;
-CREATE TABLE `whitelist`  (
+CREATE TABLE IF NOT EXISTS `whitelist`  (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `identifier` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
   `status` boolean,
-  `firstconnection` boolean,
+  `firstconnection` boolean DEFAULT TRUE,
   PRIMARY KEY (`id`) USING BTREE,
   UNIQUE INDEX `identifier`(`identifier`) USING BTREE
 ) ENGINE = InnoDB AUTO_INCREMENT = 1 CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci ROW_FORMAT = DYNAMIC;
@@ -20,8 +18,7 @@ CREATE TABLE IF NOT EXISTS `users` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 
-DROP TABLE IF EXISTS `characters`;
-CREATE TABLE `characters`  (
+CREATE TABLE IF NOT EXISTS `characters`  (
   `identifier` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '',
   `charidentifier` int(11) NOT NULL AUTO_INCREMENT,
   `steamname` varchar(50) COLLATE utf8mb4_bin NOT NULL DEFAULT '',
@@ -44,3 +41,11 @@ CREATE TABLE `characters`  (
   INDEX `charidentifier`(`charidentifier`) USING BTREE,
   CONSTRAINT `FK_characters_users` FOREIGN KEY (`identifier`) REFERENCES `users` (`identifier`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE = InnoDB AUTO_INCREMENT = 1 CHARACTER SET = utf8mb4 COLLATE = utf8mb4_bin ROW_FORMAT = DYNAMIC;
+
+
+-------------ANY NEW UPDATES TO THE TABLES ABOVE NEED TO HAVE TABLE ALTERS ALSO ADDED BELOW FOR THOSE WHO ALREADY HAVE SERVERS RUNNING.
+-- The following updates tables that were not included in the original table (Support for those who already have the tables above)
+ALTER TABLE `users` ALTER COLUMN  `banned` boolean;
+ALTER TABLE `users` ADD `banneduntil` int(10) DEFAULT 0;
+ALTER TABLE `whitelist` ADD `status` boolean
+ALTER TABLE `whitelist` ADD `firstconnection` boolean


### PR DESCRIPTION
Bugfix for NewPlayerWebhook for servers with existing users enabled whitelist policy. Whitelists, bans and warns should be now fully functional as expected.

**IMPORTANT!** On running (existing) servers must be run the following query to make it working.
```
ALTER TABLE `whitelist`
ADD COLUMN `firstconnection` boolean DEFAULT TRUE AFTER `status`
```
The query adds extra flag to db to ensure sending webhooks even after restarts between whitelisting and player's first connection.

New servers can use updated vorpv2.sql