### PR TITLE
DB Auto Updater added to Core API

### DIFF
--- a/server/services/dbupdater/dbupdater.lua
+++ b/server/services/dbupdater/dbupdater.lua
@@ -5,6 +5,7 @@ local dbversion = nil
 local Tables = {
     {
         name = "whitelist",
+        script = "vorp_core",
         sql = [[
             CREATE TABLE IF NOT EXISTS `whitelist`  (
             `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -18,6 +19,7 @@ local Tables = {
     },
     {
         name = "users",
+        script = "vorp_core",
         sql = [[
             CREATE TABLE IF NOT EXISTS `users` (
             `identifier` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
@@ -32,6 +34,7 @@ local Tables = {
     },
     {
         name = "characters",
+        script = "vorp_core",
         sql = [[
             CREATE TABLE IF NOT EXISTS `characters`  (
             `identifier` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '',
@@ -65,12 +68,14 @@ local Tables = {
 local Updates = {
     {
         name = "banned",
+        script = "vorp_core",
         sql = [[
             ALTER TABLE `users` MODIFY COLUMN  `banned` boolean;
         ]]
     },
     {
         name = "banneduntil",
+        script = "vorp_core",
         find = [[
             select *
             from Information_Schema.Columns
@@ -83,6 +88,7 @@ local Updates = {
     },
     {
         name = "status",
+        script = "vorp_core",
         find = [[
             select *
             from Information_Schema.Columns
@@ -95,6 +101,7 @@ local Updates = {
     },
     {
         name = "firstconnection",
+        script = "vorp_core",
         find = [[
             select *
             from Information_Schema.Columns
@@ -107,6 +114,7 @@ local Updates = {
     },
     {
         name = "steamname",
+        script = "vorp_core",
         find = [[
             select *
             from Information_Schema.Columns
@@ -119,6 +127,7 @@ local Updates = {
     },
     {
         name = "char",
+        script = "vorp_core",
         find = [[
             select *
             from Information_Schema.Columns
@@ -131,6 +140,7 @@ local Updates = {
     },
     {
         name = "ammo",
+        script = "vorp_core",
         find = [[
             select *
             from Information_Schema.Columns
@@ -143,6 +153,7 @@ local Updates = {
     },
     {
         name = "ammoindex",
+        script = "vorp_core",
         find = [[
             select *
             from Information_Schema.Columns
@@ -155,6 +166,21 @@ local Updates = {
     }
 }
 
+dbupdaterAPI = {
+}
+
+dbupdaterAPI.addTables = function (tbls)
+    for _, tbl in ipairs(tbls) do 
+        table.insert(Tables, tbl)
+    end
+end
+
+dbupdaterAPI.addUpdates = function (updts)
+    for _, updt in ipairs(updts) do 
+        table.insert(Updates, updt)
+    end
+end
+
 local function runSQLList(list, type)
     for index, it in ipairs(list) do
         local hascolumn = false
@@ -162,7 +188,7 @@ local function runSQLList(list, type)
             local isfound = exports.ghmattimysql:executeSync(it.find)
             if #isfound > 0 then
                 hascolumn = true
-                print('^4Database Updater ^3('..GetCurrentResourceName()..')^2✅ Column Exists: ' .. it.name .. ' ^0')
+                print('^4Database Auto Updater ^3('..it.script..')^2✅ Column Exists: ' .. it.name .. ' ^0')
             end
         end
 
@@ -178,7 +204,7 @@ local function runSQLList(list, type)
                 else 
                     out = '^1❌ ('..dbversion..') Failed to Updated: '
                 end
-                print('^4Database Updater ^3('..GetCurrentResourceName()..')' .. out .. it.name .. ' ^0')
+                print('^4Database Auto Updater ^3('..it.script..')' .. out .. it.name .. ' ^0')
             else
                 local out = ''
                 if type == 'table' then
@@ -187,7 +213,7 @@ local function runSQLList(list, type)
                 else 
                     out = 'Updated Column: '
                 end
-                print('^4Database Updater ^3('..GetCurrentResourceName()..')^2✅ ' .. out .. it.name .. '^0')
+                print('^4Database Auto Updater ^3('..it.script..')^2✅ ' .. out .. it.name .. '^0')
             end 
         end
     end
@@ -236,7 +262,7 @@ Citizen.CreateThread(function()
     if updated then
         SaveResourceFile(GetCurrentResourceName(), "./server/services/dbupdater/status.json", json.encode(status))
     else
-        print('^4Database Updater ^3('..GetCurrentResourceName()..')^2✅ Database('..dbversion..') is up to date^0')
+        print('^4Database Auto Updater ^3('..dbversion..')^2✅ Database is up to date^0')
     end
 
     print('^0###############################################################################')

--- a/server/services/dbupdater/status.json
+++ b/server/services/dbupdater/status.json
@@ -1,1 +1,1 @@
-{"updatecount":12,"tablecount":5}
+{"tablecount":0,"updatecount":0}

--- a/server/services/dbupdater/status.json
+++ b/server/services/dbupdater/status.json
@@ -1,1 +1,1 @@
-{"tablecount":0,"updatecount":0}
+{"updatecount":12,"tablecount":5}

--- a/server/sv_apicontroller.lua
+++ b/server/sv_apicontroller.lua
@@ -172,7 +172,19 @@ AddEventHandler('getCore', function(cb)
         TriggerClientEvent('vorp:warningNotify', _source, title, msg, audioRef, audioName, duration)
     end
 
-  
+    coreData.dbUpdateAddTables = function (tbl)
+        if VorpInitialized == true then
+            print('Updates must be added before vorpcore is initiates')
+        end
+        dbupdaterAPI.addTables(tbl)
+    end
+
+    coreData.dbUpdateAddUpdates = function (updt)
+        if VorpInitialized == true then
+            print('Updates must be added before vorpcore is initiates')
+        end
+        dbupdaterAPI.addUpdates(updt)
+    end
 
     cb(coreData)
 end)


### PR DESCRIPTION
**_What has changed:_**
1. Database auto updater has been externalized via the getCore API

**_Example usage in external scripts:_**
```lua
VorpCore = {}

TriggerEvent("getCore",function(core)
    VorpCore = core
end)

local Tables = {
    {
        name = "loadout",
        script = "vorp_inventory",
        sql = [[
            CREATE TABLE IF NOT EXISTS `loadout` (
                `id` INT(11) NOT NULL AUTO_INCREMENT,
                `identifier` VARCHAR(50) NOT NULL,
                `charidentifier` INT(11) NULL,
                `name` VARCHAR(50) NULL DEFAULT NULL,
                `ammo` VARCHAR(255) NOT NULL DEFAULT '{}',
                `components` VARCHAR(255) NOT NULL DEFAULT '[]',
                `dirtlevel` DOUBLE NULL DEFAULT 0,
                `mudlevel` DOUBLE NULL DEFAULT 0,
                `conditionlevel` DOUBLE NULL DEFAULT 0,
                `rustlevel` DOUBLE NULL DEFAULT 0,
                `used` TINYINT(4) NULL DEFAULT 0,
                PRIMARY KEY (`id`),
                INDEX `id` (`id`)
            )
            COLLATE='utf8mb4_general_ci'
            ENGINE=InnoDB
            AUTO_INCREMENT=2;
        ]]
    }
}

local Updates = {
    {
        name = "dropped",
        script = "vorp_inventoryv",
        find = [[
            select *
            from Information_Schema.Columns
            where Table_Name = 'loadout'
            AND  Column_Name = 'dropped';
        ]],
        sql =  [[
            ALTER TABLE `loadout` ADD COLUMN `dropped` INT(11) NOT NULL DEFAULT 0;
        ]]
    }
}

Citizen.CreateThread(function()
    VorpCore.dbUpdateAddTables(Tables)
    VorpCore.dbUpdateAddUpdates(Updates)
end)
```

**_Output Example:_**
![image](https://user-images.githubusercontent.com/10902965/178076848-def21359-88f7-48be-b374-20eb3e239ce9.png)
