### PR TITLE
Feat + Tweak -> Add txMenu healing/revive compatibility and  move vorp:ImDead

### DIFF
--- a/server/sv_loadcharacter.lua
+++ b/server/sv_loadcharacter.lua
@@ -40,12 +40,15 @@ AddEventHandler('txAdmin:events:healedPlayer', function(eventData)
         local identifier = GetSteamID(Player)
         local xCharacter = _users[identifier].GetUsedCharacter()
         if xCharacter and xCharacter.isdead then
+            
             TriggerClientEvent("vorp:ShowBasicTopNotification", Player, "You Revived Yourself.", 4000)
             TriggerClientEvent('vorp:resurrectPlayer', Player)
+            TriggerClientEvent('vorp:heal', Player)
         end
     else 
         TriggerClientEvent("vorp:ShowBasicTopNotification", -1, "You Have Been Healed.", 4000)
         TriggerClientEvent('vorp:resurrectPlayer', -1)
+        TriggerClientEvent('vorp:heal', Player)
     end
 end)
 

--- a/server/sv_loadcharacter.lua
+++ b/server/sv_loadcharacter.lua
@@ -30,3 +30,21 @@ RegisterNetEvent('vorp:UpdateCharacter', function(steamId, firstname, lastname)
     characters[steamId].Firstname(firstname)
     characters[steamId].Lastname(lastname)
 end)
+
+AddEventHandler('txAdmin:events:healedPlayer', function(eventData)
+	if GetInvokingResource() ~= "monitor" or type(eventData) ~= "table" or type(eventData.id) ~= "number" then
+		return
+	end
+    local Player = eventData.id
+    if Player ~= -1 then
+        local identifier = GetSteamID(Player)
+        local xCharacter = _users[identifier].GetUsedCharacter()
+        if xCharacter and xCharacter.isdead then
+            TriggerClientEvent("vorp:ShowBasicTopNotification", Player, "You Revived Yourself.", 4000)
+            TriggerClientEvent('vorp:resurrectPlayer', Player)
+        end
+    else 
+        TriggerClientEvent("vorp:ShowBasicTopNotification", -1, "You Have Been Healed.", 4000)
+        TriggerClientEvent('vorp:resurrectPlayer', -1)
+    end
+end)

--- a/server/sv_loadcharacter.lua
+++ b/server/sv_loadcharacter.lua
@@ -48,7 +48,7 @@ AddEventHandler('txAdmin:events:healedPlayer', function(eventData)
     else 
         TriggerClientEvent("vorp:ShowBasicTopNotification", -1, "You Have Been Healed.", 4000)
         TriggerClientEvent('vorp:resurrectPlayer', -1)
-        TriggerClientEvent('vorp:heal', Player)
+        TriggerClientEvent('vorp:heal', -1)
     end
 end)
 

--- a/server/sv_loadcharacter.lua
+++ b/server/sv_loadcharacter.lua
@@ -48,3 +48,12 @@ AddEventHandler('txAdmin:events:healedPlayer', function(eventData)
         TriggerClientEvent('vorp:resurrectPlayer', -1)
     end
 end)
+
+RegisterNetEvent('vorp:ImDead', function(isDead)
+    local source = source
+    local identifier = GetSteamID(source)
+
+    if _users[identifier] then
+        _users[identifier].GetUsedCharacter().setDead(isDead)
+    end
+end)

--- a/server/sv_savecoordsdb.lua
+++ b/server/sv_savecoordsdb.lua
@@ -12,15 +12,6 @@ RegisterNetEvent('vorp:saveLastCoords', function(lastCoords, lastHeading)
     end
 end)
 
-RegisterNetEvent('vorp:ImDead', function(isDead)
-    local source = source
-    local identifier = GetSteamID(source)
-
-    if _users[identifier] then
-        _users[identifier].GetUsedCharacter().setDead(isDead)
-    end
-end)
-
 RegisterNetEvent('vorp:SaveHours', function()
     local hoursupdate = tonumber(0.5)  -- Just to be sure is giving numbers =D
     local source = source


### PR DESCRIPTION
when you use txMenu -> Heal yourself, it will heal you or resurrect you if your dead.
when you use txMenu -> Heal Everyone, it will resurrect all users. 
All tested and all working :)

Also moved the event **vorp:ImDead** to a file that made sense for its name and use case :)