### PR TITLE
Removed redundant check

### DIFF
--- a/server/sv_whitelist.lua
+++ b/server/sv_whitelist.lua
@@ -112,11 +112,6 @@ AddEventHandler("playerConnecting", function(playerName, setKickReason, deferral
         return
     end
 
-    if not steamIdentifier then
-        deferrals.done(Config.Langs.NoSteam)
-        setKickReason(Config.Langs.NoSteam)
-    end
-
     if _users[steamIdentifier] and not _usersLoading[identifier] then --Save and delete
         _users[steamIdentifier].SaveUser()
         _users[steamIdentifier] = nil


### PR DESCRIPTION
The steam id is being checked at line 108 and handled within that if statement. The deleted if statement didn't even do anything other than set a deferral (it was missing cancelling the event and returning the function)