### PR TITLE
Fix the erros with new players

### DIFF
--- a/server/sv_apicontroller.lua
+++ b/server/sv_apicontroller.lua
@@ -1,61 +1,91 @@
-AddEventHandler('vorp:getCharacter', function(player, cb)
+---@param player number
+---@return table|nil
+local function _getUsedCharacter(player)
+
     local sid = GetSteamID(player)
 
-    if _users[sid] ~= nil then
-        cb(_users[sid].GetUsedCharacter().getCharacter())
+    if not sid then
+        return nil
+    end
+
+    local used_char = _users[sid].GetUsedCharacter() or nil
+
+    return used_char
+end
+
+---@param player number
+---@return table|nil
+local function _getCharDetails(player)
+
+    local used_char = _getUsedCharacter(player)
+
+    if not used_char then
+        return nil
+    end
+
+    local char = used_char.getCharacter() or nil
+
+    return char
+end
+
+AddEventHandler('vorp:getCharacter', function(player, cb)
+    local char_details  = _getCharDetails(player)
+
+    if char_details ~= nil then
+        cb(char_details)
     end
 end)
 
 AddEventHandler('vorp:addMoney', function(player, typeCash, quantity)
-    local sid = GetSteamID(player)
+    local used_char  = _getUsedCharacter(player)
 
-    if _users[sid] ~= nil then
-        _users[sid].GetUsedCharacter().addCurrency(typeCash, quantity)
-        _users[sid].GetUsedCharacter().updateCharUi()
+    if used_char ~= nil then
+        used_char.addCurrency(typeCash, quantity)
+        used_char.updateCharUi()
     end
 end)
 
 AddEventHandler('vorp:removeMoney', function(player, typeCash, quantity)
-    local sid = GetSteamID(player)
+    local used_char  = _getUsedCharacter(player)
 
-    if _users[sid] ~= nil then
-        _users[sid].GetUsedCharacter().removeCurrency(typeCash, quantity)
-        _users[sid].GetUsedCharacter().updateCharUi()
+    if used_char ~= nil then
+        used_char.removeCurrency(typeCash, quantity)
+        used_char.updateCharUi()
     end
 end)
 
 AddEventHandler('vorp:addXp', function(player, quantity)
-    local sid = GetSteamID(player)
+    local used_char  = _getUsedCharacter(player)
 
-    if _users[sid] ~= nil then
-        _users[sid].GetUsedCharacter().addXp(quantity)
-        _users[sid].GetUsedCharacter().updateCharUi()
+    if used_char ~= nil then
+        used_char.addXp(quantity)
+        used_char.updateCharUi()
     end
 end)
 
 AddEventHandler('vorp:removeXp', function(player, quantity)
-    local sid = GetSteamID(player)
+    local used_char  = _getUsedCharacter(player)
 
-    if _users[sid] ~= nil then
-        _users[sid].GetUsedCharacter().removeXp(quantity)
-        _users[sid].GetUsedCharacter().updateCharUi()
+    if used_char ~= nil then
+        used_char.removeXp(quantity)
+        used_char.updateCharUi()
     end
 end)
 
 AddEventHandler('vorp:setJob', function(player, job, jobgrade)
-    local sid = GetSteamID(player)
+    local used_char  = _getUsedCharacter(player)
 
-    if _users[sid] ~= nil then
-        _users[sid].GetUsedCharacter().setJob(job)
-        _users[sid].GetUsedCharacter().setJobGrade(jobgrade)
+    if used_char ~= nil then
+        used_char.setJob(job)
+        used_char.setJobGrade(jobgrade)
     end
 end)
 
 AddEventHandler('vorp:setGroup', function(player, group)
-    local sid = GetSteamID(player)
+    local used_char  = _getUsedCharacter(player)
 
-    if _users[sid] ~= nil then
-        _users[sid].GetUsedCharacter().setGroup(group)
+    if used_char ~= nil then
+        used_char.setGroup(group)
     end
 end)
 


### PR DESCRIPTION
If someone triggers this event it could be possible that he awaits (example: Citizen.Await with promise) a response.
But the callback is only called if character details exists. So the promise from the example will never be resolved.
That is a bad design.
Better solution is to call the callback with nil if character details not exists, so the promise from the example will be resolved with nil. The caller should handle the "nil" case then.