### PR TITLE
RagdollOnResurrection, CanBeDamagedToSpawn and HealthRecharge

### DIFF
--- a/client/cl_respawnsystem.lua
+++ b/client/cl_respawnsystem.lua
@@ -107,24 +107,26 @@ local ResurrectPlayer = function(currentHospital, currentHospitalName)
     end
     Wait(2000)
     HealPlayer() -- heal fully the player
-    --  DoScreenFadeIn(3000)
-    keepdown = true
-    CreateThread(function() -- tread to keep player down
-        while keepdown do
-            Wait(0)
-            SetPedToRagdoll(PlayerPedId(), 4000, 4000, 0, 0, 0, 0)
-            ResetPedRagdollTimer(PlayerPedId())
-        end
-    end)
-    AnimpostfxPlay("Title_Gen_FewHoursLater")
-    Wait(3000) -- maybe add here something funny ?
-    DoScreenFadeIn(2000)
-    AnimpostfxPlay("PlayerWakeUpInterrogation") -- disabled
-    Wait(19000)
-    keepdown = false
+    if Config.RagdollOnResurrection then
+        --  DoScreenFadeIn(3000)
+        keepdown = true
+        CreateThread(function() -- tread to keep player down
+            while keepdown do
+                Wait(0)
+                SetPedToRagdoll(PlayerPedId(), 4000, 4000, 0, 0, 0, 0)
+                ResetPedRagdollTimer(PlayerPedId())
+            end
+        end)
+        AnimpostfxPlay("Title_Gen_FewHoursLater")
+        Wait(3000) -- maybe add here something funny ?
+        DoScreenFadeIn(2000)
+        AnimpostfxPlay("PlayerWakeUpInterrogation") -- disabled
+        Wait(19000)
+        keepdown = false
+    end
     local dict = "minigames_hud"
     local icon = "five_finger_burnout"
-    TriggerEvent('vorp:NotifyLeft', currentHospitalName, Config.Langs.message5,
+    TriggerEvent('vorp:NotifyLeft', currentHospitalName or '...', Config.Langs.message5,
         dict, icon
         , 8000, "COLOR_PURE_WHITE")
 end

--- a/client/cl_respawnsystem.lua
+++ b/client/cl_respawnsystem.lua
@@ -119,11 +119,12 @@ local ResurrectPlayer = function(currentHospital, currentHospitalName)
         end)
         AnimpostfxPlay("Title_Gen_FewHoursLater")
         Wait(3000) -- maybe add here something funny ?
-        DoScreenFadeIn(2000)
-        AnimpostfxPlay("PlayerWakeUpInterrogation") -- disabled
-        Wait(19000)
-        keepdown = false
     end
+    DoScreenFadeIn(2000)
+    AnimpostfxPlay("PlayerWakeUpInterrogation") -- disabled
+    Wait(19000)
+    keepdown = false
+    
     local dict = "minigames_hud"
     local icon = "five_finger_burnout"
     TriggerEvent('vorp:NotifyLeft', currentHospitalName or '...', Config.Langs.message5,

--- a/config.lua
+++ b/config.lua
@@ -84,7 +84,9 @@ Config = {
 
     HealthOnRespawn = 500, --Player's health when respawned in hospital (MAX = 500)
     HealthOnResurrection = 100, --Player's health when resurrected (MAX = 500)
-    DisableRecharge = true, --Disable auto recharge of health outer core (real ped health)
+    RagdollOnResurrection = false, -- Enable or disable Ragdoll and revive effects when revived
+    CanBeDamagedToSpawn = false, -- The player can take damage while spawning
+    HealthRecharge = { enable = true, multiplier = 0.37 }, -- enable or disable auto recharge of health outer core (real ped health), multiplier 1.0 is default
     RespawnTime = 10, --seconds
     RespawnKey = 0xDFF812F9, --[E] KEY
     RespawnKeyTime = 5000, -- Milliseconds it will take to press the button


### PR DESCRIPTION
RagdollOnResurrection: This option will allow you to disable Ragdoll and the screen effects when revived. Also added '...' to the notification dict when not revived in a hospital.

CanBeDamagedToSpawn: This option will make players immortal while they are connecting and charge health.

HealthRecharge: This option will allow you to enable or disable the recharge of life and the multiplier, so that it costs more or less time to recover life. It will also apply the multiplier and prevent it from recharging health when HealthRecharge.enable is false when the player uses the /rc command.