### PR TITLE
fix(cl_respawnsystem: Correctly pass 'justrevive')

### DIFF
--- a/client/cl_respawnsystem.lua
+++ b/client/cl_respawnsystem.lua
@@ -227,7 +227,7 @@ end)
 RegisterNetEvent('vorp:resurrectPlayer', function(just)
     local dont = false
     local justrevive = just or true
-    ResurrectPlayer(dont, justrevive)
+    ResurrectPlayer(dont, nil, justrevive)
 end)
 
 -- respawn player from server side


### PR DESCRIPTION
This commit correctly passes the variables  `currentHospitalName` and `justrevive` used in the following function.

LINE 89: `local ResurrectPlayer = function(currentHospital, currentHospitalName, justrevive)`