### PR TITLE
The command addGroup set admins on both table! 

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -147,6 +147,7 @@ Config = {
     ----------------------------------------------------------------------------
     --------------------------- COMMAND PERMISSION -----------------------------
     SetUserDBadmin = true, -- should the command addGroup set admins on Users table? for characters table do set false
+    SetBothDBadmin = true, -- if set true should the command addGroup set admins on both table!
     GroupAllowed = { "admin" }, -- add here groups
     -- dont change this unless you change them in sv_commands too
     Commands = { "addGroup", "addJob", "addItems", "addWeapons", "addMoney", "delMoney", "healplayer",

--- a/server/sv_commands.lua
+++ b/server/sv_commands.lua
@@ -110,6 +110,10 @@ CreateThread(function()
                         else
                             CharacterT.setGroup(newgroup)
                         end
+                        if Config.SetBothDBadmin then
+                            UserT.setGroup(newgroup)
+                            CharacterT.setGroup(newgroup)
+                        end
                         VorpCore.NotifyRightTip(_source, "You gave Group to ID: " .. target, 4000)
                         VorpCore.NotifyRightTip(_source, "Admin gave you Group of " .. newgroup, 4000)
 


### PR DESCRIPTION
If enabled in the config, the command addGroup set admins on both tables (users, characters)