### PR TITLE
NotifyLeft color fix

### DIFF
--- a/client/cl_clientapi.lua
+++ b/client/cl_clientapi.lua
@@ -35,7 +35,7 @@ AddEventHandler('getCore', function(cb)
             LoadTexture(dict)
         end
         exports.vorp_core:DisplayLeftNotification(tostring(title), tostring(subtitle), tostring(dict), tostring(icon),
-            tonumber(duration), tostring(color))
+            tonumber(duration), tostring(color or "COLOR_WHITE"))
     end
 
     corefunctions.NotifyRightTip = function(text, duration)


### PR DESCRIPTION
When a notification runs with no color it appears purple, these changes will set the color to white when it doesn't run with a color.