### PR TITLE
use column names in insert users query

### DIFF
--- a/server/sv_loadusers.lua
+++ b/server/sv_loadusers.lua
@@ -39,7 +39,7 @@ function LoadUser(source, setKickReason, deferrals, identifier, license)
         deferrals.done()
     else
         --New User
-        MySQL.insert("INSERT INTO users VALUES(?,?,?,?,?,?)", { identifier, "user", 0, 0, 0, "false" })
+        MySQL.insert("INSERT INTO users (identifier, group, warnings, banned, banneduntil, char) VALUES (?,?,?,?,?,?)", { identifier, "user", 0, 0, 0, "false" })
         _users[identifier] = User(source, identifier, "user", 0, license)
         deferrals.done()
     end


### PR DESCRIPTION
Leaving column names out could lead to errors on the serverowners side if they have any other extra column in this table