### PR TITLE
SavePlayersStatus fix

### DIFF
--- a/client/cl_spawnplayer.lua
+++ b/client/cl_spawnplayer.lua
@@ -165,18 +165,7 @@ RegisterNetEvent('vorp:initCharacter', function(coords, heading, isdead)
             Wait(1000)
             ShutdownLoadingScreen()
         end
-        if Config.SavePlayersStatus then
-            TriggerServerEvent("vorp:GetValues")
-            Wait(10000)
-            Citizen.InvokeNative(0xC6258F41D86676E0, player, 0, HealthData.hInner)
-            SetEntityHealth(player, HealthData.hOuter + HealthData.hInner)
-            Citizen.InvokeNative(0xC6258F41D86676E0, player, 1, HealthData.sInner)
-            Citizen.InvokeNative(0x675680D089BFA21F, player, HealthData.sOuter / 1065353215 * 100)
-            HealthData = {}
-        else
-            HealPlayer()
-        end
-
+        
         if not Config.HealthRecharge.enable then
             Citizen.InvokeNative(0x8899C244EBCF70DE, PlayerId(), 0.0) -- SetPlayerHealthRechargeMultiplier
         else
@@ -189,6 +178,18 @@ RegisterNetEvent('vorp:initCharacter', function(coords, heading, isdead)
         else
             Citizen.InvokeNative(0xFECA17CF3343694B, PlayerId(), Config.StaminaRecharge.multiplier) -- SetPlayerStaminaRechargeMultiplier
             multiplierStamina = Citizen.InvokeNative(0x617D3494AD58200F, PlayerId()) -- GetPlayerStaminaRechargeMultiplier
+        end
+
+        if Config.SavePlayersStatus then
+            TriggerServerEvent("vorp:GetValues")
+            Wait(10000)
+            Citizen.InvokeNative(0xC6258F41D86676E0, PlayerPedId(), 0, HealthData.hInner)
+            SetEntityHealth(PlayerPedId(), HealthData.hOuter + HealthData.hInner)
+            Citizen.InvokeNative(0xC6258F41D86676E0, PlayerPedId(), 1, HealthData.sInner)
+            Citizen.InvokeNative(0x675680D089BFA21F, PlayerPedId(), HealthData.sOuter / 1065353215 * 100)
+            HealthData = {}
+        else
+            HealPlayer()
         end
     end
 end)

--- a/client/cl_spawnplayer.lua
+++ b/client/cl_spawnplayer.lua
@@ -127,7 +127,6 @@ end)
 --================================ EVENTS ============================================--
 
 RegisterNetEvent('vorp:initCharacter', function(coords, heading, isdead)
-    local player = PlayerPedId()
     TeleportToCoords(coords, heading) -- teleport player to coords
 
     if isdead then -- is player dead
@@ -165,7 +164,7 @@ RegisterNetEvent('vorp:initCharacter', function(coords, heading, isdead)
             Wait(1000)
             ShutdownLoadingScreen()
         end
-        
+
         if not Config.HealthRecharge.enable then
             Citizen.InvokeNative(0x8899C244EBCF70DE, PlayerId(), 0.0) -- SetPlayerHealthRechargeMultiplier
         else
@@ -183,10 +182,11 @@ RegisterNetEvent('vorp:initCharacter', function(coords, heading, isdead)
         if Config.SavePlayersStatus then
             TriggerServerEvent("vorp:GetValues")
             Wait(10000)
-            Citizen.InvokeNative(0xC6258F41D86676E0, PlayerPedId(), 0, HealthData.hInner)
-            SetEntityHealth(PlayerPedId(), HealthData.hOuter + HealthData.hInner)
-            Citizen.InvokeNative(0xC6258F41D86676E0, PlayerPedId(), 1, HealthData.sInner)
-            Citizen.InvokeNative(0x675680D089BFA21F, PlayerPedId(), HealthData.sOuter / 1065353215 * 100)
+            local player = PlayerPedId()
+            Citizen.InvokeNative(0xC6258F41D86676E0, player, 0, HealthData.hInner)
+            SetEntityHealth(player, HealthData.hOuter + HealthData.hInner)
+            Citizen.InvokeNative(0xC6258F41D86676E0, player, 1, HealthData.sInner)
+            Citizen.InvokeNative(0x675680D089BFA21F, player, HealthData.sOuter / 1065353215 * 100)
             HealthData = {}
         else
             HealPlayer()

--- a/server/sv_loadusers.lua
+++ b/server/sv_loadusers.lua
@@ -50,7 +50,7 @@ AddEventHandler('playerDropped', function()
     local steamName = GetPlayerName(_source)
     local pCoords, pHeading
 
-    if config.onesync then
+    if Config.onesync then
         pCoords = GetEntityCoords(GetPlayerPed(_source))
         pHeading = GetEntityHeading(GetPlayerPed(_source))
     end


### PR DESCRIPTION
The bug reappeared after the last vorp_core updates, it always appears with half of innercore health. It seems that adding PlayerPedId() fixes the problem, it might reload the character before that.

The order of the multiplier has also been changed, it will restore health and stamina while loading life and stamina from the database.

The Config variable was called as 'config' in the sv_loadusers.lua file and it failed to disconnect from the server and connected dead.