### PR TITLE
Add event to notify client of instance change

### DIFF
--- a/server/sv_instance.lua
+++ b/server/sv_instance.lua
@@ -50,6 +50,8 @@ AddEventHandler("vorp_core:instanceplayers", function(setRoom)
         src,
         instanceSource
     )
+    
+    TriggerClientEvent('vorp_core:instanceChanged', src, instanceSource)
 end)
 
 -- credits to MrDankKetchup


### PR DESCRIPTION
Created to remove the race condition of hooking the server event and adding a wait to detect session change completion.

Specific Use Case: Reapplying entity ownership when coming back to main instance.

Can be used by client scripts to after triggering an instance change to ensure it has been completed rather than utilizing waits and hoping they are long enough.