### PR TITLE
CanBeDamaged fix

### DIFF
--- a/client/spawnplayer.lua
+++ b/client/spawnplayer.lua
@@ -64,6 +64,7 @@ AddEventHandler('vorp:initCharacter', function(coords, heading, isdead)
             if Config.Loadinscreen then
                 Citizen.InvokeNative(0x1E5B70E53DB661E5, 0, 0, 0, T.forcedrespawn, T.forced, T.Almost)
             end
+            SetEntityCanBeDamaged(PlayerPedId(), true)
             TriggerServerEvent("vorp:PlayerForceRespawn")
             TriggerEvent("vorp:PlayerForceRespawn")
             CoreAction.Player.RespawnPlayer()
@@ -107,6 +108,8 @@ AddEventHandler('vorp:initCharacter', function(coords, heading, isdead)
             multiplierStamina = Citizen.InvokeNative(0x617D3494AD58200F, PlayerId) -- GetPlayerStaminaRechargeMultiplier
         end
 
+        SetEntityCanBeDamaged(PlayerPedId(), true)
+
         if Config.SavePlayersStatus then
             TriggerServerEvent("vorp:GetValues")
             Wait(10000)
@@ -132,7 +135,6 @@ RegisterNetEvent("vorp:SelectedCharacter", function()
     CoreAction.Utils.setPVP()
     local PlayerPed = PlayerPedId()
     local PlayerId = PlayerId()
-    SetEntityCanBeDamaged(PlayerPed, true)
     Citizen.InvokeNative(0xA63FCAD3A6FEC6D2, PlayerId, Config.ActiveEagleEye)
     Citizen.InvokeNative(0x95EE1DEE1DCD9070, PlayerId, Config.ActiveDeadEye)
     TriggerEvent("vorp:showUi", not Config.HideUi)


### PR DESCRIPTION
After updating vorp_core, I had reports that players were not taking damage. It seems to happen regularly to some players.

These changes seem to work, perhaps a wait on vorp:SelectedCharacter was necessary, but this works without changing the process.

It was a quick check and fix for my server, maybe not the best way to fix it.